### PR TITLE
refactor: streamline reader UI and Chinese-only TTS

### DIFF
--- a/gpt5parallel-reader.html
+++ b/gpt5parallel-reader.html
@@ -6,9 +6,9 @@
 <title>Parallel Text Reader (Single File)</title>
 <style>
   :root {
-    --bg: #f7f7fb;
+    --bg: #f0f4ff;
     --card: #ffffff;
-    --primary: #2563eb;
+    --primary: #1d4ed8;
     --text: #111827;
     --muted: #6b7280;
     --shadow: 0 6px 18px rgba(0,0,0,0.08);
@@ -21,7 +21,7 @@
     background: var(--bg); color: var(--text);
   }
   header {
-    background: linear-gradient(135deg, var(--primary), #4f46e5);
+    background: linear-gradient(135deg, var(--primary), #3b82f6);
     color: #fff; text-align: center;
     padding: 0.8rem 1rem; border-radius: var(--radius);
     box-shadow: var(--shadow);
@@ -59,14 +59,13 @@
     overflow-y: auto; box-shadow: inset 0 0 0 1px #f1f5f9;
     white-space: pre-wrap; line-height: 1.6;
   }
-  /* 1.5x height for English */
-  #englishDisplay { height: 45vh; }
-  #chineseDisplay { height: 30vh; }
+  /* Taller pane for English with scrolling */
+  #englishDisplay { max-height: 70vh; }
   .toolbar {
     display: grid; gap: 0.5rem;
   }
   @media (min-width: 560px){
-    .toolbar { grid-template-columns: 1fr auto auto auto; align-items: end; }
+    .toolbar { grid-template-columns: 1fr auto auto; align-items: end; }
   }
   .pill {
     display: inline-flex; align-items: center; gap: 0.5rem;
@@ -123,7 +122,7 @@
       <div class="row row-cols">
         <button id="loadManual" class="primary">Load Text</button>
         <div class="stack">
-          <label><input type="checkbox" id="autoTTS" checked /> Auto TTS (EN → ZH)</label>
+          <label><input type="checkbox" id="autoTTS" checked /> Auto Chinese TTS</label>
         </div>
       </div>
     </section>
@@ -132,13 +131,11 @@
     <section class="card row">
       <div class="toolbar">
         <div class="pill" id="nowReading">Now reading: —</div>
-        <button id="replayEN" class="ghost">Replay English</button>
         <button id="replayZH" class="ghost">Replay Chinese</button>
         <button id="stopAll" class="ghost">Stop Audio</button>
       </div>
       <div class="reader">
         <div class="pane" id="englishDisplay" aria-label="English text"></div>
-        <div class="pane" id="chineseDisplay" aria-label="Chinese text"></div>
       </div>
     </section>
 
@@ -153,7 +150,7 @@ const statusPill = document.getElementById('statusPill');
 const nowReading = document.getElementById('nowReading');
 
 const englishDisplay = document.getElementById('englishDisplay');
-const chineseDisplay = document.getElementById('chineseDisplay');
+let currentChinese = '';
 
 const englishInput = document.getElementById('englishInput');
 const chineseInput = document.getElementById('chineseInput');
@@ -162,7 +159,6 @@ const autoTTS = document.getElementById('autoTTS');
 const csvInput = document.getElementById('csvInput');
 const loadManualBtn = document.getElementById('loadManual');
 const clearAllBtn = document.getElementById('clearAll');
-const replayENBtn = document.getElementById('replayEN');
 const replayZHBtn = document.getElementById('replayZH');
 const stopAllBtn = document.getElementById('stopAll');
 
@@ -293,7 +289,7 @@ storySelector.addEventListener('change', () => {
   if (!ds || Number.isNaN(idx)) return;
   const story = ds.stories[idx];
   displayStory(story, `${ds.fileName} • ${story.title}`);
-  if (autoTTS.checked) speakBoth(story.english, story.chinese);
+  if (autoTTS.checked) speakChinese(story.chinese);
   updateStatus();
 });
 
@@ -302,7 +298,7 @@ clearAllBtn.addEventListener('click', () => {
   updateFileSelector();
   updateStatus();
   englishDisplay.textContent = '';
-  chineseDisplay.textContent = '';
+  currentChinese = '';
   nowReading.textContent = 'Now reading: —';
   stopSpeaking();
 });
@@ -312,28 +308,26 @@ loadManualBtn.addEventListener('click', () => {
   const eng = englishInput.value ?? '';
   const chi = chineseInput.value ?? '';
   displayStory({ english: eng, chinese: chi, title: '(Manual)' }, '(Manual)');
-  if (autoTTS.checked) speakBoth(eng, chi);
+  if (autoTTS.checked) speakChinese(chi);
 });
 
 /* ========= Display ========= */
 function displayStory(story, label){
   englishDisplay.textContent = story.english || '';
-  chineseDisplay.textContent = story.chinese || '';
+  currentChinese = story.chinese || '';
   nowReading.textContent = `Now reading: ${label || (story.title ?? '—')}`;
   // scroll to top each time
   englishDisplay.scrollTop = 0;
-  chineseDisplay.scrollTop = 0;
 }
 
 /* ========= TTS ========= */
 let voices = [];
-let enVoice = null, zhVoice = null;
+let zhVoice = null;
 
 function loadVoices(){
   return new Promise(resolve => {
     const handler = () => {
       voices = speechSynthesis.getVoices();
-      enVoice = pickVoice(['en-US','en-GB','en']);
       zhVoice = pickVoice(['zh-CN','zh-TW','zh']);
       resolve();
     };
@@ -352,14 +346,8 @@ function pickVoice(preferredLangs){
     const match = v.find(x => (x.lang || '').toLowerCase().startsWith(lang.toLowerCase()));
     if (match) return match;
   }
-  // any English/Chinese voice
-  if (preferredLangs[0].startsWith('en')) {
-    return v.find(x => (x.lang || '').toLowerCase().startsWith('en')) || null;
-  }
-  if (preferredLangs[0].startsWith('zh')) {
-    return v.find(x => (x.lang || '').toLowerCase().startsWith('zh')) || null;
-  }
-  return null;
+  // fallback to any Chinese voice
+  return v.find(x => (x.lang || '').toLowerCase().startsWith('zh')) || null;
 }
 
 function speak(text, lang, voice){
@@ -376,36 +364,19 @@ function stopSpeaking(){
   speechSynthesis.cancel();
 }
 
-async function speakBoth(english, chinese){
+async function speakChinese(chinese){
   if (!('speechSynthesis' in window)) return;
   stopSpeaking();
   await loadVoices();
 
   return new Promise(resolve => {
-    const enUtter = speak(english, (enVoice?.lang || 'en-US'), enVoice);
-    if (!enUtter) { // if no english, just speak chinese
-      const zhUtter = speak(chinese, (zhVoice?.lang || 'zh-CN'), zhVoice);
-      if (!zhUtter) return resolve();
-      zhUtter.onend = () => resolve();
-      return;
-    }
-    enUtter.onend = () => {
-      const zhUtter = speak(chinese, (zhVoice?.lang || 'zh-CN'), zhVoice);
-      if (!zhUtter) return resolve();
-      zhUtter.onend = () => resolve();
-    };
+    const zhUtter = speak(chinese, (zhVoice?.lang || 'zh-CN'), zhVoice);
+    if (!zhUtter) return resolve();
+    zhUtter.onend = () => resolve();
   });
 }
-
-replayENBtn.addEventListener('click', async () => {
-  stopSpeaking();
-  await loadVoices();
-  speak(englishDisplay.textContent, (enVoice?.lang || 'en-US'), enVoice);
-});
 replayZHBtn.addEventListener('click', async () => {
-  stopSpeaking();
-  await loadVoices();
-  speak(chineseDisplay.textContent, (zhVoice?.lang || 'zh-CN'), zhVoice);
+  await speakChinese(currentChinese);
 });
 stopAllBtn.addEventListener('click', stopSpeaking);
 


### PR DESCRIPTION
## Summary
- remove Chinese text pane and English TTS controls
- enlarge scrollable English pane and refresh colors
- speak Chinese only via new `speakChinese` routine

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b575f68083239f270a46a208e44e