### PR TITLE
Improve playback UI and scrolling speed

### DIFF
--- a/gpt5parallel-reader.html
+++ b/gpt5parallel-reader.html
@@ -6,7 +6,7 @@
 <title>Parallel Text Reader (Single File)</title>
 <style>
   :root {
-    --bg: #f0f4ff;
+    --bg: linear-gradient(to bottom, #87CEEB, #E0F7FF);
     --card: #ffffff;
     --primary: #1d4ed8;
     --text: #111827;
@@ -111,7 +111,7 @@
     <section class="card row">
       <div class="toolbar">
         <div class="pill" id="nowReading">Now reading: —</div>
-        <button id="replayZH" class="ghost">Replay Chinese</button>
+        <button id="playZH" class="ghost">Play Chinese</button>
         <button id="stopAll" class="ghost">Stop Audio</button>
       </div>
       <div class="reader">
@@ -138,7 +138,7 @@ let currentChinese = '';
 
 const csvInput = document.getElementById('csvInput');
 const clearAllBtn = document.getElementById('clearAll');
-const replayZHBtn = document.getElementById('replayZH');
+const playZHBtn = document.getElementById('playZH');
 const stopAllBtn = document.getElementById('stopAll');
 const scrollSpeed = document.getElementById('scrollSpeed');
 
@@ -296,7 +296,7 @@ scrollSpeed.addEventListener('input', () => {
   }
   const speed = parseInt(scrollSpeed.value, 10);
   if (speed > 0) {
-    const delay = 1000 / speed;
+    const delay = 1000 / (speed * 1.4);
     scrollInterval = setInterval(() => {
       englishDisplay.scrollTop += 1;
     }, delay);
@@ -367,7 +367,7 @@ async function speakChinese(chinese){
     zhUtter.onend = () => resolve();
   });
 }
-replayZHBtn.addEventListener('click', async () => {
+playZHBtn.addEventListener('click', async () => {
   await speakChinese(currentChinese);
 });
 stopAllBtn.addEventListener('click', stopSpeaking);

--- a/parallel-reader-library-pwa/index.html
+++ b/parallel-reader-library-pwa/index.html
@@ -8,7 +8,7 @@
 <meta name="theme-color" content="#2563eb">
 <style>
   :root {
-    --bg: #f9fafb;
+    --bg: linear-gradient(to bottom, #87CEEB, #E0F7FF);
     --card: #ffffff;
     --primary: #1f2937;
     --text: #1f2937;
@@ -132,7 +132,7 @@
     <section class="card row">
       <div class="toolbar">
         <div class="pill" id="nowReading">Now reading: —</div>
-        <button id="replayZH" class="ghost">Replay</button>
+        <button id="playZH" class="ghost">Play Chinese</button>
         <button id="stopAll" class="ghost">Stop Audio</button>
       </div>
       <div class="reader">
@@ -159,7 +159,7 @@ const autoTTS = document.getElementById('autoTTS');
 const csvInput = document.getElementById('csvInput');
 const loadManualBtn = document.getElementById('loadManual');
 const clearAllBtn = document.getElementById('clearAll');
-const replayZHBtn = document.getElementById('replayZH');
+const playZHBtn = document.getElementById('playZH');
 const stopAllBtn = document.getElementById('stopAll');
 
 let currentEnglishLines = [];
@@ -403,7 +403,7 @@ async function speakChineseLines(){
   speakNext();
 }
 
-replayZHBtn.addEventListener('click', speakChineseLines);
+playZHBtn.addEventListener('click', speakChineseLines);
 stopAllBtn.addEventListener('click', stopSpeaking);
 
 /* ========= Status ========= */


### PR DESCRIPTION
## Summary
- Accelerate auto-scroll by ~40% and rename Chinese playback button to "Play Chinese"
- Add sky-blue gradient background while keeping English pane white
- Mirror button label and background updates in the PWA version

## Testing
- ⚠️ `npx prettier -c gpt5parallel-reader.html parallel-reader-library-pwa/index.html` (style issues reported)
- ⚠️ `npm test` (package.json missing)


------
https://chatgpt.com/codex/tasks/task_e_68a4cbbdea7c83238f4c1f59492d22ad