### PR TITLE
Add sentence drilling PWA

### DIFF
--- a/sentence-drill-pwa/app.js
+++ b/sentence-drill-pwa/app.js
@@ -1,0 +1,175 @@
+const deckKey = 'sdDeck';
+const statsKey = 'sdStats';
+const settingsKey = 'sdSettings';
+let deck = [];
+let stats = { drilled: 0, unique: 0 };
+let settings = { voice: null, rate: 1, repetitions: 1, shadow: false };
+let current = null;
+
+function saveState() {
+  localStorage.setItem(deckKey, JSON.stringify(deck));
+  localStorage.setItem(statsKey, JSON.stringify(stats));
+  localStorage.setItem(settingsKey, JSON.stringify(settings));
+}
+
+function loadState() {
+  const d = localStorage.getItem(deckKey);
+  const s = localStorage.getItem(statsKey);
+  const set = localStorage.getItem(settingsKey);
+  if (d) deck = JSON.parse(d);
+  if (s) stats = JSON.parse(s);
+  if (set) settings = { ...settings, ...JSON.parse(set) };
+  document.getElementById('repetitions').value = settings.repetitions;
+  document.getElementById('rate').value = settings.rate;
+  document.getElementById('shadowMode').checked = settings.shadow;
+  updateProgress();
+}
+
+function updateProgress() {
+  const progress = document.getElementById('progress');
+  progress.textContent = `Progress: ${stats.unique}/${deck.length}`;
+}
+
+function populateVoices() {
+  const voices = speechSynthesis.getVoices();
+  const select = document.getElementById('voiceSelect');
+  select.innerHTML = '';
+  voices.forEach((v, i) => {
+    const opt = document.createElement('option');
+    opt.value = i;
+    opt.textContent = `${v.name} (${v.lang})`;
+    if (settings.voice && settings.voice === v.name) opt.selected = true;
+    select.appendChild(opt);
+  });
+}
+
+speechSynthesis.onvoiceschanged = populateVoices;
+
+function speak(text, rep) {
+  let count = 0;
+  function once() {
+    const utter = new SpeechSynthesisUtterance(text);
+    const voices = speechSynthesis.getVoices();
+    const voiceIndex = document.getElementById('voiceSelect').value;
+    utter.voice = voices[voiceIndex] || null;
+    utter.rate = parseFloat(document.getElementById('rate').value);
+    utter.onend = () => {
+      count++;
+      if (count < rep) {
+        const delay = settings.shadow ? 700 : 0;
+        setTimeout(once, delay);
+      }
+    };
+    speechSynthesis.speak(utter);
+  }
+  once();
+}
+
+function nextItem() {
+  const now = Date.now();
+  const due = deck.filter(item => !item.next || item.next <= now);
+  if (!due.length) {
+    document.getElementById('sentence').textContent = 'All done for now';
+    document.getElementById('translation').textContent = '';
+    current = null;
+    return;
+  }
+  // randomize
+  const item = due[Math.floor(Math.random() * due.length)];
+  current = item;
+  document.getElementById('sentence').textContent = item.text;
+  document.getElementById('translation').textContent = item.translation || '';
+  speak(item.text, settings.repetitions);
+}
+
+function schedule(item, again) {
+  if (again) {
+    item.interval = 1; // minutes
+  } else {
+    item.interval = item.interval ? item.interval * 2 : 1;
+  }
+  item.next = Date.now() + item.interval * 60 * 1000;
+  if (!item.reps) item.reps = 0;
+  if (item.reps === 0) stats.unique++;
+  item.reps++;
+  stats.drilled++;
+  saveState();
+  updateProgress();
+}
+
+function handleResult(again) {
+  if (!current) return;
+  schedule(current, again);
+  nextItem();
+}
+
+function parseCSV(text) {
+  const lines = text.split(/\r?\n/);
+  lines.forEach((line, idx) => {
+    const [text, translation] = line.split(',');
+    if (text) deck.push({ id: idx + 1, text: text.trim(), translation: translation ? translation.trim() : '', interval: 0, next: 0, reps: 0 });
+  });
+  saveState();
+  updateProgress();
+  document.getElementById('drill-section').hidden = false;
+  nextItem();
+}
+
+function importFile(file) {
+  const reader = new FileReader();
+  reader.onload = e => parseCSV(e.target.result);
+  reader.readAsText(file);
+}
+
+function fetchCSV(url) {
+  fetch(url).then(r => r.text()).then(parseCSV);
+}
+
+// Event listeners
+const fileInput = document.getElementById('csvFile');
+fileInput.addEventListener('change', e => {
+  const file = e.target.files[0];
+  if (file) importFile(file);
+});
+
+document.getElementById('fetchCsv').addEventListener('click', () => {
+  const url = document.getElementById('csvUrl').value;
+  if (url) fetchCSV(url);
+});
+
+document.getElementById('againBtn').addEventListener('click', () => handleResult(true));
+document.getElementById('goodBtn').addEventListener('click', () => handleResult(false));
+
+document.getElementById('voiceSelect').addEventListener('change', e => {
+  const voices = speechSynthesis.getVoices();
+  settings.voice = voices[e.target.value] ? voices[e.target.value].name : null;
+  saveState();
+});
+
+document.getElementById('repetitions').addEventListener('change', e => {
+  settings.repetitions = parseInt(e.target.value, 10);
+  saveState();
+});
+
+document.getElementById('rate').addEventListener('change', e => {
+  settings.rate = parseFloat(e.target.value);
+  saveState();
+});
+
+document.getElementById('shadowMode').addEventListener('change', e => {
+  settings.shadow = e.target.checked;
+  saveState();
+});
+
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('./sw.js');
+}
+
+window.addEventListener('load', () => {
+  loadState();
+  populateVoices();
+  if (deck.length) {
+    document.getElementById('drill-section').hidden = false;
+    nextItem();
+  }
+});

--- a/sentence-drill-pwa/index.html
+++ b/sentence-drill-pwa/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sentence Drill PWA</title>
+  <link rel="manifest" href="manifest.webmanifest" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <h1>Sentence Drill</h1>
+  <section id="import-section">
+    <h2>Import Sentences</h2>
+    <input type="file" id="csvFile" accept="text/csv" />
+    <input type="url" id="csvUrl" placeholder="CSV URL" />
+    <button id="fetchCsv">Fetch CSV</button>
+  </section>
+
+  <section id="settings-section">
+    <h2>Settings</h2>
+    <label>Voice:
+      <select id="voiceSelect"></select>
+    </label>
+    <label>Rate:
+      <input type="range" id="rate" min="0.5" max="2" step="0.1" value="1" />
+    </label>
+    <label>Repetitions:
+      <input type="number" id="repetitions" min="1" max="5" value="1" />
+    </label>
+    <label>
+      <input type="checkbox" id="shadowMode" /> Shadowing mode
+    </label>
+  </section>
+
+  <section id="drill-section" hidden>
+    <h2 id="progress">Progress: 0/0</h2>
+    <p id="sentence"></p>
+    <p id="translation"></p>
+    <button id="againBtn">Again</button>
+    <button id="goodBtn">Good</button>
+  </section>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/sentence-drill-pwa/manifest.webmanifest
+++ b/sentence-drill-pwa/manifest.webmanifest
@@ -1,0 +1,9 @@
+{
+  "name": "Sentence Drill",
+  "short_name": "Drill",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "description": "Glossika-style sentence drilling PWA",
+  "icons": []
+}

--- a/sentence-drill-pwa/sample-sentences.csv
+++ b/sentence-drill-pwa/sample-sentences.csv
@@ -1,0 +1,3 @@
+Hello,你好
+How are you?,你好吗
+I am learning Chinese.,我在学中文

--- a/sentence-drill-pwa/style.css
+++ b/sentence-drill-pwa/style.css
@@ -1,0 +1,16 @@
+body {
+  font-family: sans-serif;
+  margin: 1rem;
+}
+#sentence {
+  font-size: 1.5rem;
+  margin-top: 1rem;
+}
+#translation {
+  color: #555;
+  margin-bottom: 1rem;
+}
+button {
+  margin-right: 0.5rem;
+  padding: 0.5rem 1rem;
+}

--- a/sentence-drill-pwa/sw.js
+++ b/sentence-drill-pwa/sw.js
@@ -1,0 +1,18 @@
+const CACHE = 'sentence-drill-cache-v1';
+const ASSETS = [
+  './',
+  './index.html',
+  './style.css',
+  './app.js',
+  './manifest.webmanifest'
+];
+self.addEventListener('install', e => {
+  e.waitUntil(
+    caches.open(CACHE).then(cache => cache.addAll(ASSETS))
+  );
+});
+self.addEventListener('fetch', e => {
+  e.respondWith(
+    caches.match(e.request).then(resp => resp || fetch(e.request))
+  );
+});


### PR DESCRIPTION
## Summary
- add new PWA for Glossika-style sentence drilling with CSV import, voice selection, and spaced-repetition scheduling
- support adjustable speech rate, repetitions, and optional shadowing mode
- track drilling progress in local storage and work offline via service worker

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/chinese/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68aca41aebf4832390583a999c3d272e