### PR TITLE
Add study sessions and confetti animation

### DIFF
--- a/sentence-drill-pwa/app.js
+++ b/sentence-drill-pwa/app.js
@@ -3,6 +3,13 @@ let deck = [];
 let settings = { voice: null, rate: 1, repetitions: 1 };
 let studyIndex = 0;
 
+function shuffle(array) {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+}
+
 function saveSettings() {
   localStorage.setItem(settingsKey, JSON.stringify(settings));
 }
@@ -76,6 +83,7 @@ function splitCSVLine(line) {
 
 function parseCSV(text) {
   deck = [];
+  studyIndex = 0;
   const lines = text.split(/\r?\n/);
   lines.forEach((line, idx) => {
     if (!line.trim()) return;
@@ -90,6 +98,7 @@ function parseCSV(text) {
       });
     }
   });
+  shuffle(deck);
   document.getElementById('drill-section').hidden = false;
   updateProgress();
 }
@@ -118,6 +127,11 @@ function celebrate() {
 
 function startStudy() {
   if (!deck.length) return;
+  if (studyIndex >= deck.length) {
+    studyIndex = 0;
+    shuffle(deck);
+    updateProgress();
+  }
   const reps = parseInt(document.getElementById('repetitions').value, 10);
   const subset = deck.slice(studyIndex, studyIndex + 5);
   if (!subset.length) return;

--- a/sentence-drill-pwa/index.html
+++ b/sentence-drill-pwa/index.html
@@ -8,25 +8,26 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <h1>Sentence Drill</h1>
-  <section id="import-section">
-    <h2>Import Sentences</h2>
-    <input type="file" id="csvFile" accept="text/csv" />
-    <input type="url" id="csvUrl" placeholder="CSV URL" />
-    <button id="fetchCsv">Fetch CSV</button>
-  </section>
+  <div class="container">
+    <h1>Sentence Drill</h1>
+    <section id="import-section">
+      <h2>Import Sentences</h2>
+      <input type="file" id="csvFile" accept="text/csv" />
+      <input type="url" id="csvUrl" placeholder="CSV URL" />
+      <button id="fetchCsv">Fetch CSV</button>
+    </section>
 
-  <section id="settings-section">
-    <h2>Settings</h2>
-    <label>Voice:
-      <select id="voiceSelect"></select>
-    </label>
-    <label>Rate:
-      <input type="range" id="rate" min="0.5" max="2" step="0.1" value="1" />
-    </label>
-    <label>Repetitions:
-      <input type="number" id="repetitions" min="1" max="5" value="1" />
-    </label>
+    <section id="settings-section">
+      <h2>Settings</h2>
+      <label>Voice:
+        <select id="voiceSelect"></select>
+      </label>
+      <label>Rate:
+        <input type="range" id="rate" min="0.5" max="2" step="0.1" value="1" />
+      </label>
+      <label>Repetitions:
+        <input type="number" id="repetitions" min="1" max="5" value="1" />
+      </label>
     </section>
 
     <section id="drill-section" hidden>
@@ -37,8 +38,9 @@
       <button id="studyBtn">Study</button>
       <p id="message" class="message" hidden></p>
     </section>
+  </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
-    <script src="app.js"></script>
-  </body>
-  </html>
+  <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/sentence-drill-pwa/index.html
+++ b/sentence-drill-pwa/index.html
@@ -27,19 +27,18 @@
     <label>Repetitions:
       <input type="number" id="repetitions" min="1" max="5" value="1" />
     </label>
-    <label>
-      <input type="checkbox" id="shadowMode" /> Shadowing mode
-    </label>
-  </section>
+    </section>
 
-  <section id="drill-section" hidden>
-    <h2 id="progress">Progress: 0/0</h2>
-    <p id="sentence"></p>
-    <p id="translation"></p>
-    <button id="againBtn">Again</button>
-    <button id="goodBtn">Good</button>
-  </section>
+    <section id="drill-section" hidden>
+      <h2 id="progress">Progress: 0/0</h2>
+      <p id="word"></p>
+      <p id="sentence"></p>
+      <p id="translation"></p>
+      <button id="studyBtn">Study</button>
+      <p id="message" class="message" hidden></p>
+    </section>
 
-  <script src="app.js"></script>
-</body>
-</html>
+    <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
+    <script src="app.js"></script>
+  </body>
+  </html>

--- a/sentence-drill-pwa/sample-sentences.csv
+++ b/sentence-drill-pwa/sample-sentences.csv
@@ -1,3 +1,5 @@
-Hello,你好
-How are you?,你好吗
-I am learning Chinese.,我在学中文
+"Hello - 你好","你好,世界","Hello, world"
+"Goodbye - 再见","再见,我的朋友","Goodbye, my friend"
+"Learn - 学习",我在学习中文,"I'm studying Chinese"
+"Friend - 朋友",他是我的朋友,He is my friend
+"Thank you - 谢谢",谢谢你的帮助,Thank you for your help

--- a/sentence-drill-pwa/style.css
+++ b/sentence-drill-pwa/style.css
@@ -1,6 +1,8 @@
 body {
   font-family: sans-serif;
   margin: 1rem;
+  background: linear-gradient(135deg, #d8f3dc, #b7e4c7);
+  min-height: 100vh;
 }
 #sentence {
   font-size: 1.5rem;
@@ -13,4 +15,14 @@ body {
 button {
   margin-right: 0.5rem;
   padding: 0.5rem 1rem;
+}
+
+#word {
+  font-weight: bold;
+}
+
+.message {
+  font-size: 1.25rem;
+  margin-top: 1rem;
+  color: #1b4332;
 }

--- a/sentence-drill-pwa/style.css
+++ b/sentence-drill-pwa/style.css
@@ -1,24 +1,58 @@
 body {
-  font-family: sans-serif;
-  margin: 1rem;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+  margin: 0;
   background: linear-gradient(135deg, #d8f3dc, #b7e4c7);
   min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
+
+.container {
+  background: rgba(255, 255, 255, 0.85);
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  text-align: center;
+  max-width: 600px;
+  width: 100%;
+}
+
+section {
+  margin-bottom: 1.5rem;
+}
+
 #sentence {
   font-size: 1.5rem;
   margin-top: 1rem;
 }
+
 #translation {
   color: #555;
   margin-bottom: 1rem;
 }
+
 button {
   margin-right: 0.5rem;
   padding: 0.5rem 1rem;
+  background-color: #2d6a4f;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.3s;
+}
+
+button:hover {
+  background-color: #40916c;
 }
 
 #word {
   font-weight: bold;
+}
+
+#progress {
+  color: #1b4332;
 }
 
 .message {


### PR DESCRIPTION
## Summary
- Show 5-sentence study sessions triggered by a **Study** button with celebratory confetti and messages after each set.
- Parse updated CSV format with vocabulary column, handling quoted fields containing commas.
- Refresh styling with a light green gradient background.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node` stubbed-dom script verifying progress tracking and confetti output

------
https://chatgpt.com/codex/tasks/task_e_68acb0bab7c88323b6733acd1b67d312