### PR TITLE
Use PapaParse for CSV parsing in sentence drill

### DIFF
--- a/sentence-drill.html
+++ b/sentence-drill.html
@@ -64,6 +64,7 @@
   </section>
 
   <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
   <script>
     const settingsKey = 'sdSettings';
     let deck = [];
@@ -122,7 +123,26 @@
       progress.textContent = `Completed ${Math.min(studyIndex, deck.length)}/${deck.length}`;
     }
 
-
+    function parseCSV(text) {
+      deck = [];
+      studyIndex = 0;
+      const result = Papa.parse(text, { skipEmptyLines: true });
+      result.data.forEach((row, idx) => {
+        if (!row || row.length < 3) return;
+        if (idx === 0 && row[0] && row[0].charCodeAt(0) === 0xFEFF) {
+          row[0] = row[0].slice(1);
+        }
+        const [word, sentence, translation] = row;
+        deck.push({
+          word: (word || '').trim(),
+          text: (sentence || '').trim(),
+          translation: (translation || '').trim()
+        });
+      });
+      if (deck.length) {
+        document.getElementById('drill-section').hidden = false;
+        updateProgress();
+      }
     }
 
     function importFile(file) {


### PR DESCRIPTION
## Summary
- Add PapaParse CDN script to sentence-drill.html
- Parse CSV input with PapaParse to handle quoted commas and special characters

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68ae7a030a0883238f892cf24a46c737