### PR TITLE
feat: persist study progress

### DIFF
--- a/sentence-drill-pwa/app.js
+++ b/sentence-drill-pwa/app.js
@@ -1,7 +1,17 @@
 const settingsKey = 'sdSettings';
+const studyIndexKey = 'sdStudyIndex';
 let deck = [];
 let settings = { voice: null, rate: 1, repetitions: 1 };
 let studyIndex = 0;
+
+function saveStudyIndex() {
+  localStorage.setItem(studyIndexKey, studyIndex);
+}
+
+function loadStudyIndex() {
+  const idx = parseInt(localStorage.getItem(studyIndexKey), 10);
+  studyIndex = isNaN(idx) ? 0 : idx;
+}
 
 
 function saveSettings() {
@@ -59,11 +69,16 @@ function updateProgress() {
 
 function parseCSV(text) {
   deck = [];
-  studyIndex = 0;
+  loadStudyIndex();
   const lines = text.split(/\r?\n/);
-  lines.forEach((line, idx) => {
+  lines.forEach(line => {
     if (!line.trim()) return;
-
+    const parts = line.split(',');
+    if (parts.length >= 3) {
+      const [word, sentence, translation] = parts;
+      deck.push({ word, text: sentence, translation });
+    }
+  });
   document.getElementById('drill-section').hidden = false;
   updateProgress();
 }
@@ -100,6 +115,7 @@ function startStudy() {
   function next() {
     if (idx >= subset.length) {
       studyIndex += subset.length;
+      saveStudyIndex();
       updateProgress();
       celebrate();
       return;
@@ -153,4 +169,5 @@ if ('serviceWorker' in navigator) {
 window.addEventListener('load', () => {
   loadSettings();
   populateVoices();
+  loadStudyIndex();
 });

--- a/sentence-drill.html
+++ b/sentence-drill.html
@@ -65,10 +65,20 @@
 
   <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
   <script>
-    const settingsKey = 'sdSettings';
-    let deck = [];
-    let settings = { voice: null, rate: 1, repetitions: 1 };
-    let studyIndex = 0;
+      const settingsKey = 'sdSettings';
+      const studyIndexKey = 'sdStudyIndex';
+      let deck = [];
+      let settings = { voice: null, rate: 1, repetitions: 1 };
+      let studyIndex = 0;
+
+      function saveStudyIndex() {
+        localStorage.setItem(studyIndexKey, studyIndex);
+      }
+
+      function loadStudyIndex() {
+        const idx = parseInt(localStorage.getItem(studyIndexKey), 10);
+        studyIndex = isNaN(idx) ? 0 : idx;
+      }
 
     function saveSettings() {
       localStorage.setItem(settingsKey, JSON.stringify(settings));
@@ -155,10 +165,11 @@
       let idx = 0;
       function next() {
         if (idx >= subset.length) {
-          studyIndex += subset.length;
-          updateProgress();
-          celebrate();
-          return;
+            studyIndex += subset.length;
+            saveStudyIndex();
+            updateProgress();
+            celebrate();
+            return;
         }
         const item = subset[idx];
         document.getElementById('word').textContent = item.word;
@@ -204,6 +215,7 @@
     window.addEventListener('load', () => {
       loadSettings();
       populateVoices();
+      loadStudyIndex();
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- save study index to localStorage and restore it on load
- update study progress increment logic to persist location

## Testing
- `npm test` (fails: could not read package.json)
- `node --check sentence-drill-pwa/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae7a100090832393718d79aec12841