### PR TITLE
Add configurable batch size

### DIFF
--- a/sentence-drill-pwa/app.js
+++ b/sentence-drill-pwa/app.js
@@ -1,6 +1,6 @@
 const settingsKey = 'sdSettings';
 let deck = [];
-let settings = { voice: null, rate: 1, repetitions: 1 };
+let settings = { voice: null, rate: 1, repetitions: 1, batchSize: 5 };
 let studyIndex = 0;
 
 
@@ -13,6 +13,7 @@ function loadSettings() {
   if (set) settings = { ...settings, ...JSON.parse(set) };
   document.getElementById('repetitions').value = settings.repetitions;
   document.getElementById('rate').value = settings.rate;
+  document.getElementById('batchSize').value = settings.batchSize;
 }
 
 function populateVoices() {
@@ -94,7 +95,8 @@ function startStudy() {
   if (!deck.length) return;
 
   const reps = parseInt(document.getElementById('repetitions').value, 10);
-  const subset = deck.slice(studyIndex, studyIndex + 5);
+  const batch = parseInt(document.getElementById('batchSize').value, 10);
+  const subset = deck.slice(studyIndex, studyIndex + batch);
   if (!subset.length) return;
   let idx = 0;
   function next() {
@@ -141,6 +143,11 @@ document.getElementById('repetitions').addEventListener('change', e => {
 
 document.getElementById('rate').addEventListener('change', e => {
   settings.rate = parseFloat(e.target.value);
+  saveSettings();
+});
+
+document.getElementById('batchSize').addEventListener('change', e => {
+  settings.batchSize = parseInt(e.target.value, 10);
   saveSettings();
 });
 

--- a/sentence-drill-pwa/index.html
+++ b/sentence-drill-pwa/index.html
@@ -17,7 +17,20 @@
       <button id="fetchCsv">Fetch CSV</button>
     </section>
 
-
+    <section id="settings-section">
+      <h2>Settings</h2>
+      <label>Voice:
+        <select id="voiceSelect"></select>
+      </label>
+      <label>Rate:
+        <input type="range" id="rate" min="0.5" max="2" step="0.1" value="1" />
+      </label>
+      <label>Repetitions:
+        <input type="number" id="repetitions" min="1" max="5" value="1" />
+      </label>
+      <label>Batch Size:
+        <input type="number" id="batchSize" min="1" max="50" value="5" />
+      </label>
     </section>
 
     <section id="drill-section" hidden>
@@ -28,4 +41,10 @@
       <button id="studyBtn">Study</button>
       <p id="message" class="message" hidden></p>
     </section>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
+  <script src="app.js"></script>
+</body>
+</html>
 

--- a/sentence-drill.html
+++ b/sentence-drill.html
@@ -49,10 +49,13 @@
     <label>Rate:
       <input type="range" id="rate" min="0.5" max="2" step="0.1" value="1" />
     </label>
-    <label>Repetitions:
-      <input type="number" id="repetitions" min="1" max="5" value="1" />
-    </label>
-  </section>
+      <label>Repetitions:
+        <input type="number" id="repetitions" min="1" max="5" value="1" />
+      </label>
+      <label>Batch Size:
+        <input type="number" id="batchSize" min="1" max="50" value="5" />
+      </label>
+    </section>
 
   <section id="drill-section" hidden>
     <h2 id="progress">Progress: 0/0</h2>
@@ -67,7 +70,7 @@
   <script>
     const settingsKey = 'sdSettings';
     let deck = [];
-    let settings = { voice: null, rate: 1, repetitions: 1 };
+      let settings = { voice: null, rate: 1, repetitions: 1, batchSize: 5 };
     let studyIndex = 0;
 
     function saveSettings() {
@@ -77,8 +80,9 @@
     function loadSettings() {
       const set = localStorage.getItem(settingsKey);
       if (set) settings = { ...settings, ...JSON.parse(set) };
-      document.getElementById('repetitions').value = settings.repetitions;
-      document.getElementById('rate').value = settings.rate;
+        document.getElementById('repetitions').value = settings.repetitions;
+        document.getElementById('rate').value = settings.rate;
+        document.getElementById('batchSize').value = settings.batchSize;
     }
 
     function populateVoices() {
@@ -150,7 +154,8 @@
     function startStudy() {
       if (!deck.length) return;
       const reps = parseInt(document.getElementById('repetitions').value, 10);
-      const subset = deck.slice(studyIndex, studyIndex + 5);
+      const batch = parseInt(document.getElementById('batchSize').value, 10);
+      const subset = deck.slice(studyIndex, studyIndex + batch);
       if (!subset.length) return;
       let idx = 0;
       function next() {
@@ -196,6 +201,11 @@
 
     document.getElementById('rate').addEventListener('change', e => {
       settings.rate = parseFloat(e.target.value);
+      saveSettings();
+    });
+
+    document.getElementById('batchSize').addEventListener('change', e => {
+      settings.batchSize = parseInt(e.target.value, 10);
       saveSettings();
     });
 


### PR DESCRIPTION
## Summary
- allow users to set a batch size for study sessions (default 5)
- persist batch size setting alongside voice, rate and repetitions
- use the configured batch size when slicing the deck in `startStudy`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7a16913c8323888f6753547726aa