### PR TITLE
Add settings section and fix HTML structure

### DIFF
--- a/sentence-drill-pwa/index.html
+++ b/sentence-drill-pwa/index.html
@@ -17,7 +17,14 @@
       <button id="fetchCsv">Fetch CSV</button>
     </section>
 
-
+    <section id="settings-section">
+      <h2>Settings</h2>
+      <label for="voiceSelect">Voice:</label>
+      <select id="voiceSelect"></select>
+      <label for="rate">Rate:</label>
+      <input type="number" id="rate" value="1" min="0.5" max="2" step="0.1" />
+      <label for="repetitions">Repetitions:</label>
+      <input type="number" id="repetitions" value="1" min="1" />
     </section>
 
     <section id="drill-section" hidden>
@@ -28,4 +35,7 @@
       <button id="studyBtn">Study</button>
       <p id="message" class="message" hidden></p>
     </section>
-
+  </div>
+  <script src="./app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add settings section to choose voice, rate, and repetitions
- Remove stray closing tag and properly close HTML document
- Load app.js script at end of body

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7ee0dcb08323839322b917f82f34